### PR TITLE
Specify File and Line informations to eval to preserve backtraces

### DIFF
--- a/lib/rspec/eventmachine/async_steps.rb
+++ b/lib/rspec/eventmachine/async_steps.rb
@@ -10,8 +10,8 @@ module RSpec::EM
 
       return if instance_methods(false).map { |m| m.to_s }.include?(async_method_name) or
                 method_name.to_s =~ /^async_/
-      
-      module_eval <<-RUBY
+
+      module_eval <<-RUBY, __FILE__, __LINE__ + 1
         alias :#{async_method_name} :#{method_name}
 
         def #{method_name}(*args)
@@ -62,7 +62,7 @@ end
 class RSpec::Core::Example
   hook_method = %w[with_around_hooks with_around_each_hooks with_around_example_hooks].find { |m| instance_method(m) rescue nil }
 
-  class_eval %Q{
+  class_eval <<-RUBY, __FILE__, __LINE__ + 1
     alias :synchronous_run :#{hook_method}
     
     def #{hook_method}(*args, &block)
@@ -74,5 +74,5 @@ class RSpec::Core::Example
         synchronous_run(*args, &block)
       end
     end
-  }
+  RUBY
 end


### PR DESCRIPTION
When an error occurs in a spec, due to `eval`, the backtrace may be lost :

```
Failure/Error: Unable to find matching line from backtrace
     NoMethodError:
       undefined method `pop' for nil:NilClass
     # (eval):6:in `with_around_each_hooks'
```

This PR adds the correct infos to `module_eval` and `class_eval` to preserve the backtrace when an error occurs.

Cheers
