### PR TITLE
fix ruby instance variable initialization warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: ruby
 
+before_install:
+  - gem update --system
+  - gem update bundler
+
 rvm:
   - 1.9.2
   - 1.9.3

--- a/lib/rspec/eventmachine/async_steps.rb
+++ b/lib/rspec/eventmachine/async_steps.rb
@@ -24,9 +24,13 @@ module RSpec::EM
       def __enqueue__(args)
         @__step_queue__ ||= []
         @__step_queue__ << args
-        return if @__running_steps__
+        return if __running_steps__
         @__running_steps__ = true
         EventMachine.next_tick { __run_next_step__ }
+      end
+
+      def __running_steps__
+        @__running_steps__ ||= false
       end
       
       def __run_next_step__

--- a/rspec-eventmachine.gemspec
+++ b/rspec-eventmachine.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name              = 'rspec-eventmachine'
-  s.version           = '0.2.0'
+  s.version           = '0.2.1'
   s.summary           = 'RSpec extensions for testing EventMachine code'
   s.author            = 'James Coglan'
   s.email             = 'jcoglan@gmail.com'


### PR DESCRIPTION
Running RSpec with enabled warnings results in:

```
/.../gems/rspec-eventmachine-0.2.0/lib/rspec/eventmachine/async_steps.rb:27: warning: instance variable @__running_steps__ not initialized
```

This PR fixes this problem by adding getter `__running_steps__`.
