### PR TITLE
Verify if the test was executed until the end

### DIFF
--- a/lib/rspec/eventmachine/async_steps.rb
+++ b/lib/rspec/eventmachine/async_steps.rb
@@ -56,7 +56,7 @@ module RSpec::EM
       end
 
       def verify_step_queue
-        unless @__step_queue__&.empty?
+        if @__step_queue__&.size&.positive?
           raise RuntimeError.new("EventMachine terminated before the end of the spec. #{@__step_queue__.size} async steps left to execute: #{@__step_queue__.map(&:first).join(', ')}")
         end
       end

--- a/lib/rspec/eventmachine/async_steps.rb
+++ b/lib/rspec/eventmachine/async_steps.rb
@@ -56,7 +56,7 @@ module RSpec::EM
       end
 
       def verify_step_queue
-        unless @__step_queue__.empty?
+        unless @__step_queue__&.empty?
           raise RuntimeError.new("EventMachine terminated before the end of the spec. #{@__step_queue__.size} async steps left to execute: #{@__step_queue__.map(&:first).join(', ')}")
         end
       end

--- a/lib/rspec/eventmachine/async_steps.rb
+++ b/lib/rspec/eventmachine/async_steps.rb
@@ -54,6 +54,12 @@ module RSpec::EM
       def teardown_mocks_for_rspec
         EventMachine.reactor_running? ? false : super
       end
+
+      def verify_step_queue
+        unless @__step_queue__.empty?
+          raise RuntimeError.new("EventMachine terminated before the end of the spec. #{@__step_queue__.size} async steps left to execute: #{@__step_queue__.map(&:first).join(', ')}")
+        end
+      end
     end
     
   end
@@ -70,6 +76,7 @@ class RSpec::Core::Example
         EventMachine.run { synchronous_run(*args, &block) }
         @example_group_instance.verify_mocks_for_rspec
         @example_group_instance.teardown_mocks_for_rspec
+        @example_group_instance.verify_step_queue
       else
         synchronous_run(*args, &block)
       end

--- a/spec/rspec/eventmachine/async_steps_spec.rb
+++ b/spec/rspec/eventmachine/async_steps_spec.rb
@@ -82,6 +82,13 @@ describe RSpec::EM::AsyncSteps do
       subtract 7
       check_result 11
     end
+
+    it "raises if spec is interrupted" do
+      multiply 6, 3
+      subtract 7
+      check_result 25 # wrong value
+      EM.stop
+    end
   end
 end
 

--- a/spec/rspec/eventmachine/async_steps_spec.rb
+++ b/spec/rspec/eventmachine/async_steps_spec.rb
@@ -89,6 +89,10 @@ describe RSpec::EM::AsyncSteps do
       check_result 25 # wrong value
       EM.stop
     end
+
+    it "do not raise if interrupted with no queue" do
+      EM.stop
+    end
   end
 end
 


### PR DESCRIPTION
Hi again @jcoglan,

We've been using rspec-em for a while to test our EM code (mostly using `faye`), thanks for this little library by the way!
I noticed something annoying when trying a diagnose some specs that were all passing but not actually testing anything (breaking the code or the spec would still show everything green). After some advanced `puts` debugging I found that it was caused by some `after :each` that was (deep down) stopping EventMachine and this was occurring *before* the spec was finished (that's normal because of the asynchronous nature).

But I was really surprised that this doesn't raise anything or show any error so I tried to write a small patch to protect against this case, simply by checking at the end of the spec (once EM is stopped) that the queued steps have all been executed (otherwise it means there was a problem). Here is my patch along with a spec that shows the problem.

Here is the new spec, it is supposed to fail because of the wrong value but actually passes without showing any error or warning because of the sneaky EM.stop:
```ruby
    it "raises if spec is interrupted" do
      multiply 6, 3
      subtract 7
      check_result 25 # wrong value
      EM.stop
    end
```

Result before my patch:
```
> rspec
.................
```

Result after my patch:
```
> rspec
.....F...........

Failures:

  1) RSpec::EventMachine::AsyncSteps RSpec example raises if spec is interrupted
     Failure/Error: raise RuntimeError.new("EventMachine terminated before the end of the spec. #{@__step_queue__.size} async steps left to execute: #{@__step_queue__.map(&:first).join(', ')}")
     
     RuntimeError:
       EventMachine terminated before the end of the spec. 2 async steps left to execute: async_subtract, async_check_result
     # ./lib/rspec/eventmachine/async_steps.rb:60:in `verify_step_queue'
     # ./lib/rspec/eventmachine/async_steps.rb:79:in `with_around_example_hooks'
```

It doesn't look great but at least it shows the problem which is important. I tested this fix on my spec suite, it triggered on all the specs that were having the problem (early EM.stop) and after fixing that I didn't saw any false-positive.

The spec is here as an example though because we don't want to keep a spec that raises, and I'm not sure how to write a proper `expect {}.to raise` here because the exception is outside the spec. If you validate the idea I can try to spend more time finding a way to write a spec that would catch the exception.

Let me know what you think, and if you want me to do some changes.

Thanks again and stay safe !