### PR TITLE
Ensure mocks teardown even when spec fails

### DIFF
--- a/lib/rspec/eventmachine/async_steps.rb
+++ b/lib/rspec/eventmachine/async_steps.rb
@@ -69,7 +69,6 @@ class RSpec::Core::Example
       if @example_group_instance.is_a?(RSpec::EM::AsyncSteps::Scheduler)
         EventMachine.run { synchronous_run(*args, &block) }
         @example_group_instance.verify_mocks_for_rspec
-        @example_group_instance.verify_step_queue
       else
         synchronous_run(*args, &block)
       end

--- a/lib/rspec/eventmachine/async_steps.rb
+++ b/lib/rspec/eventmachine/async_steps.rb
@@ -69,10 +69,12 @@ class RSpec::Core::Example
       if @example_group_instance.is_a?(RSpec::EM::AsyncSteps::Scheduler)
         EventMachine.run { synchronous_run(*args, &block) }
         @example_group_instance.verify_mocks_for_rspec
-        @example_group_instance.teardown_mocks_for_rspec
+        @example_group_instance.verify_step_queue
       else
         synchronous_run(*args, &block)
       end
+    ensure
+      @example_group_instance.teardown_mocks_for_rspec if @example_group_instance.is_a?(RSpec::EM::AsyncSteps::Scheduler)
     end
   RUBY
 end

--- a/spec/rspec/eventmachine/async_steps_spec.rb
+++ b/spec/rspec/eventmachine/async_steps_spec.rb
@@ -82,6 +82,17 @@ describe RSpec::EM::AsyncSteps do
       subtract 7
       check_result 11
     end
+
+    it "leaks a mock" do
+      allow(Object).to receive(:toto) { puts 'toto' }   
+      EM.add_timer(0.1) {
+        expect(1).to eq(2)
+      }
+    end
+
+    it "has leaked mock" do
+      multiply 6, 3
+      Object.toto
+    end
   end
 end
-


### PR DESCRIPTION
In rspec when a spec fails it stops without continuing but it still removes the mocks to prevent from leaking on other specs

https://github.com/rspec/rspec-core/blob/71823ba11ec17a73b25bdc24ebab195494c270dc/lib/rspec/core/example.rb#L521

We should do the same in rspec-em because currently failing specs leak on other specs which is not practical on big CI suites

FTR I couldnt find a way to make a spec on this, since we would need a failing spec, rspec doesn't seem to spec their ensure either but maybe I just wasn't lucky/smart enough to find it in a short time

I still added a proof of work in specs, although it relies on the fact that a spec fails so it shouldnt be kept

```
bundle exec rspec --order defined --format documentation spec/rspec/eventmachine/async_steps_spec.rb:77
Run options: include {:locations=>{"./spec/rspec/eventmachine/async_steps_spec.rb"=>[77]}}

RSpec::EventMachine::AsyncSteps
  RSpec example
    passes
    leaks a mock (FAILED - 1)
toto
    has leaked mock

Failures:

  1) RSpec::EventMachine::AsyncSteps RSpec example leaks a mock
     Failure/Error: expect(1).to eq(2)
     
       expected: 2
            got: 1

```

With the fix

```
bundle exec rspec --order defined --format documentation spec/rspec/eventmachine/async_steps_spec.rb:77
Run options: include {:locations=>{"./spec/rspec/eventmachine/async_steps_spec.rb"=>[77]}}

RSpec::EventMachine::AsyncSteps
  RSpec example
    passes
    leaks a mock (FAILED - 1)
    has leaked mock (FAILED - 2)

Failures:

  1) RSpec::EventMachine::AsyncSteps RSpec example leaks a mock
     Failure/Error: expect(1).to eq(2)
     
       expected: 2
            got: 1
     
       (compared using ==)
     # ./spec/rspec/eventmachine/async_steps_spec.rb:89:in `block (4 levels) in <top (required)>'
     # ./lib/rspec/eventmachine/async_steps.rb:70:in `with_around_example_hooks'

  2) RSpec::EventMachine::AsyncSteps RSpec example has leaked mock
     Failure/Error: Object.toto
     
     NoMethodError:
       undefined method `toto' for Object:Class
     # ./spec/rspec/eventmachine/async_steps_spec.rb:95:in `block (3 levels) in <top (required)>'
     # ./lib/rspec/eventmachine/async_steps.rb:70:in `block in with_around_example_hooks'
     # ./lib/rspec/eventmachine/async_steps.rb:70:in `with_around_example_hooks'

```
